### PR TITLE
Rework mappings so that it is compatible with es 6 & 5

### DIFF
--- a/elasticsearch/api.go
+++ b/elasticsearch/api.go
@@ -68,7 +68,7 @@ func (api *API) AddDimensionOption(ctx context.Context, instanceID, dimension st
 		return 0, errors.New("missing dimension option code")
 	}
 
-	path := api.url + "/" + instanceID + "_" + dimension + "/hierarchy/" + dimensionOption.Code
+	path := api.url + "/" + instanceID + "_" + dimension + "/dimension_option/" + dimensionOption.Code
 
 	bytes, err := json.Marshal(dimensionOption)
 	if err != nil {

--- a/elasticsearch/mappings.json
+++ b/elasticsearch/mappings.json
@@ -37,39 +37,35 @@
 					"fields": {
 						"raw": {
 							"analyzer": "raw_analyzer",
-							"type": "string",
+							"type": "text",
 							"index_options": "docs",
-							"norms": {
-								"enabled": false
-							}
+							"norms": false
 						}
 					},
-					"type": "string"
+					"type": "keyword"
 				},
 				"label": {
 					"fields": {
 						"raw": {
 							"analyzer": "raw_analyzer",
-							"type": "string",
+							"type": "text",
 							"index_options": "docs",
-							"norms": {
-								"enabled": false
-							}
+							"norms": false
 						}
 					},
-					"type": "string"
+					"type": "text"
 				},
 				"has_data": {
-					"index": "not_analyzed",
+					"index": false,
 					"type": "boolean"
 				},
 				"number_of_children": {
-					"index": "not_analyzed",
+					"index": false,
 					"type": "integer"
 				},
 				"url": {
-					"index": "not_analyzed",
-					"type": "string"
+					"index": false,
+					"type": "keyword"
 				}
 			}
 		}


### PR DESCRIPTION
### What

Rework mappings so that it is compatible with both elasticsearch version 6 as well as 5. 

Limitation is that when querying, the matching snippets do not currently work for es version 6, this is due to elasticsearch removing the ascii code if it is found at the start of the highlighted string.

### How to review

Check changes make sense, for sanity you can run the searchAPI acceptance tests against dp-search-api to prove new mappings work (as the mappings changed here match the mappings in test).

### Who can review

Team B
