### PR TITLE
Add AWS auth signing to Elasticsearch requests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,20 +8,21 @@ import (
 
 // Config is the filing resource handler config
 type Config struct {
-	BindAddr                string        `envconfig:"BIND_ADDR"`
-	Brokers                 []string      `envconfig:"KAFKA_ADDR"`
-	ConsumerGroup           string        `envconfig:"CONSUMER_GROUP"`
-	ConsumerTopic           string        `envconfig:"HIERARCHY_BUILT_TOPIC"`
-	ElasticSearchAPIURL     string        `envconfig:"ELASTIC_SEARCH_URL"`
-	EventReporterTopic      string        `envconfig:"EVENT_REPORTER_TOPIC"`
-	GracefulShutdownTimeout time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
-	HealthcheckInterval     time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
-	HealthcheckTimeout      time.Duration `envconfig:"HEALTHCHECK_TIMEOUT"`
-	HierarchyAPIURL         string        `envconfig:"HIERARCHY_API_URL"`
-	KafkaMaxBytes           string        `envconfig:"KAFKA_MAX_BYTES"`
-	MaxRetries              int           `envconfig:"REQUEST_MAX_RETRIES"`
-	ProducerTopic           string        `envconfig:"PRODUCER_TOPIC"`
-	SearchBuilderURL        string        `envconfig:"SEARCH_BUILDER_URL"`
+	BindAddr                  string        `envconfig:"BIND_ADDR"`
+	Brokers                   []string      `envconfig:"KAFKA_ADDR"`
+	ConsumerGroup             string        `envconfig:"CONSUMER_GROUP"`
+	ConsumerTopic             string        `envconfig:"HIERARCHY_BUILT_TOPIC"`
+	ElasticSearchAPIURL       string        `envconfig:"ELASTIC_SEARCH_URL"`
+	EventReporterTopic        string        `envconfig:"EVENT_REPORTER_TOPIC"`
+	GracefulShutdownTimeout   time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
+	HealthcheckInterval       time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
+	HealthcheckTimeout        time.Duration `envconfig:"HEALTHCHECK_TIMEOUT"`
+	HierarchyAPIURL           string        `envconfig:"HIERARCHY_API_URL"`
+	KafkaMaxBytes             string        `envconfig:"KAFKA_MAX_BYTES"`
+	MaxRetries                int           `envconfig:"REQUEST_MAX_RETRIES"`
+	ProducerTopic             string        `envconfig:"PRODUCER_TOPIC"`
+	SearchBuilderURL          string        `envconfig:"SEARCH_BUILDER_URL"`
+	SignElasticsearchRequests bool          `envconfig:"SIGN_ELASTICSEARCH_REQUESTS"`
 }
 
 var cfg *Config
@@ -33,20 +34,21 @@ func Get() (*Config, error) {
 	}
 
 	cfg = &Config{
-		BindAddr:                ":22900",
-		Brokers:                 []string{"localhost:9092"},
-		ConsumerGroup:           "dp-search-builder",
-		ConsumerTopic:           "hierarchy-built",
-		ElasticSearchAPIURL:     "http://localhost:9200",
-		EventReporterTopic:      "report-events",
-		GracefulShutdownTimeout: 5 * time.Second,
-		HealthcheckInterval:     time.Minute,
-		HealthcheckTimeout:      2 * time.Second,
-		HierarchyAPIURL:         "http://localhost:22600",
-		KafkaMaxBytes:           "2000000",
-		MaxRetries:              3,
-		ProducerTopic:           "search-built",
-		SearchBuilderURL:        "http://localhost:22900",
+		BindAddr:                  ":22900",
+		Brokers:                   []string{"localhost:9092"},
+		ConsumerGroup:             "dp-search-builder",
+		ConsumerTopic:             "hierarchy-built",
+		ElasticSearchAPIURL:       "http://localhost:9200",
+		EventReporterTopic:        "report-events",
+		GracefulShutdownTimeout:   5 * time.Second,
+		HealthcheckInterval:       time.Minute,
+		HealthcheckTimeout:        2 * time.Second,
+		HierarchyAPIURL:           "http://localhost:22600",
+		KafkaMaxBytes:             "2000000",
+		MaxRetries:                3,
+		ProducerTopic:             "search-built",
+		SearchBuilderURL:          "http://localhost:22900",
+		SignElasticsearchRequests: true,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/elasticsearch/api.go
+++ b/elasticsearch/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ONSdigital/dp-search-builder/models"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/ONSdigital/go-ns/rchttp"
+	"github.com/smartystreets/go-aws-auth"
 )
 
 // ErrorUnexpectedStatusCode represents the error message to be returned when
@@ -20,15 +21,17 @@ var ErrorUnexpectedStatusCode = errors.New("unexpected status code from api")
 
 // API aggregates a client and URL and other common data for accessing the API
 type API struct {
-	client *rchttp.Client
-	url    string
+	client       *rchttp.Client
+	url          string
+	signRequests bool
 }
 
 // NewElasticSearchAPI creates an ElasticSearchAPI object
-func NewElasticSearchAPI(client *rchttp.Client, elasticSearchAPIURL string) *API {
+func NewElasticSearchAPI(client *rchttp.Client, elasticSearchAPIURL string, signRequests bool) *API {
 	return &API{
-		client: client,
-		url:    elasticSearchAPIURL,
+		client:       client,
+		url:          elasticSearchAPIURL,
+		signRequests: signRequests,
 	}
 }
 
@@ -108,6 +111,10 @@ func (api *API) CallElastic(ctx context.Context, path, method string, payload in
 	if err != nil {
 		log.ErrorC("failed to create request for call to elastic", err, logData)
 		return nil, 0, err
+	}
+
+	if api.signRequests {
+		awsauth.Sign(req)
 	}
 
 	resp, err := api.client.Do(ctx, req)

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	}
 
 	client := rchttp.DefaultClient
-	elasticSearchAPI := elasticsearch.NewElasticSearchAPI(client, cfg.ElasticSearchAPIURL)
+	elasticSearchAPI := elasticsearch.NewElasticSearchAPI(client, cfg.ElasticSearchAPIURL, cfg.SignElasticsearchRequests)
 	_, status, err := elasticSearchAPI.CallElastic(context.Background(), cfg.ElasticSearchAPIURL, "GET", nil)
 	if err != nil {
 		log.ErrorC("failed to start up, unable to connect to elastic search instance", err, log.Data{"http_status": status})
@@ -64,9 +64,10 @@ func main() {
 	}
 
 	svc := &service.Service{
-		BindAddr:            cfg.BindAddr,
-		Consumer:            syncConsumerGroup,
-		ElasticSearchURL:    cfg.ElasticSearchAPIURL,
+		BindAddr:                  cfg.BindAddr,
+		Consumer:                  syncConsumerGroup,
+		ElasticSearchURL:          cfg.ElasticSearchAPIURL,
+		SignElasticsearchRequests: cfg.SignElasticsearchRequests,
 		EnvMax:              envMax,
 		ErrorReporter:       errorReporter,
 		HealthcheckInterval: cfg.HealthcheckInterval,

--- a/service/handler.go
+++ b/service/handler.go
@@ -35,7 +35,7 @@ func (svc *Service) handleMessage(ctx context.Context, message kafka.Message) (s
 
 	apis := &APIs{
 		hierarchyAPI: hierarchy.NewHierarchyAPI(svc.HTTPClient, svc.HierarchyAPIURL),
-		elasticAPI:   elasticsearch.NewElasticSearchAPI(svc.HTTPClient, svc.ElasticSearchURL),
+		elasticAPI:   elasticsearch.NewElasticSearchAPI(svc.HTTPClient, svc.ElasticSearchURL, svc.SignElasticsearchRequests),
 	}
 
 	// Make request to Hierarchy API to get "Super Parent" for dimension

--- a/service/service.go
+++ b/service/service.go
@@ -21,20 +21,21 @@ import (
 
 // Service represents the necessary config for dp-dimension-extractor
 type Service struct {
-	EnvMax                   int64
-	BindAddr                 string
-	Consumer                 *kafka.ConsumerGroup
-	ElasticSearchURL         string
-	ErrorReporter            reporter.ImportErrorReporter
-	HealthcheckInterval      time.Duration
-	HealthcheckTimeout       time.Duration
-	HierarchyAPIURL          string
-	HTTPClient               *rchttp.Client
-	MaxRetries               int
-	SearchBuiltProducer      kafka.Producer
-	SearchBuilderErrProducer kafka.Producer
-	SearchBuilderURL         string
-	Shutdown                 time.Duration
+	EnvMax                    int64
+	BindAddr                  string
+	Consumer                  *kafka.ConsumerGroup
+	ElasticSearchURL          string
+	SignElasticsearchRequests bool
+	ErrorReporter             reporter.ImportErrorReporter
+	HealthcheckInterval       time.Duration
+	HealthcheckTimeout        time.Duration
+	HierarchyAPIURL           string
+	HTTPClient                *rchttp.Client
+	MaxRetries                int
+	SearchBuiltProducer       kafka.Producer
+	SearchBuilderErrProducer  kafka.Producer
+	SearchBuilderURL          string
+	Shutdown                  time.Duration
 }
 
 // Start handles consumption of events

--- a/vendor/github.com/smartystreets/go-aws-auth/CONTRIBUTING.md
+++ b/vendor/github.com/smartystreets/go-aws-auth/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+In general, the code posted to the [SmartyStreets github organization](https://github.com/smartystreets) is created to solve specific problems at SmartyStreets that are ancillary to our core products in the address verification industry and may or may not be useful to other organizations or developers. Our reason for posting said code isn't necessarily to solicit feedback or contributions from the community but more as a showcase of some of the approaches to solving problems we have adopted.
+
+Having stated that, we do consider issues raised by other githubbers as well as contributions submitted via pull requests. When submitting such a pull request, please follow these guidelines:
+
+- _Look before you leap:_ If the changes you plan to make are significant, it's in everyone's best interest for you to discuss them with a SmartyStreets team member prior to opening a pull request.
+- _License and ownership:_ If modifying the `LICENSE.md` file, limit your changes to fixing typographical mistakes. Do NOT modify the actual terms in the license or the copyright by **SmartyStreets, LLC**. Code submitted to SmartyStreets projects becomes property of SmartyStreets and must be compatible with the associated license.
+- _Testing:_ If the code you are submitting resides in packages/modules covered by automated tests, be sure to add passing tests that cover your changes and assert expected behavior and state. Submit the additional test cases as part of your change set.
+- _Style:_ Match your approach to **naming** and **formatting** with the surrounding code. Basically, the code you submit shouldn't stand out.
+  - "Naming" refers to such constructs as variables, methods, functions, classes, structs, interfaces, packages, modules, directories, files, etc...
+  - "Formatting" refers to such constructs as whitespace, horizontal line length, vertical function length, vertical file length, indentation, curly braces, etc...

--- a/vendor/github.com/smartystreets/go-aws-auth/LICENSE.md
+++ b/vendor/github.com/smartystreets/go-aws-auth/LICENSE.md
@@ -1,0 +1,23 @@
+Copyright (c) 2016 SmartyStreets
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+NOTE: Various optional and subordinate components carry their own licensing
+requirements and restrictions.  Use of those components is subject to the terms
+and conditions outlined the respective license of each component.

--- a/vendor/github.com/smartystreets/go-aws-auth/README.md
+++ b/vendor/github.com/smartystreets/go-aws-auth/README.md
@@ -1,0 +1,86 @@
+go-aws-auth
+===========
+
+[![GoDoc](https://godoc.org/github.com/smartystreets/go-aws-auth?status.svg)](http://godoc.org/github.com/smartystreets/go-aws-auth)
+
+Go-AWS-Auth is a comprehensive, lightweight library for signing requests to Amazon Web Services.
+
+It's easy to use: simply build your HTTP request and call `awsauth.Sign(req)` before sending your request over the wire.
+
+
+
+### Supported signing mechanisms
+
+- [Signed Signature Version 2](http://docs.aws.amazon.com/general/latest/gr/signature-version-2.html)
+- [Signed Signature Version 3](http://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html)
+- [Signed Signature Version 4](http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
+- [Custom S3 Authentication Scheme](http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html)
+- [Security Token Service](http://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html)
+- [S3 Query String Authentication](http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
+- [IAM Role](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials)
+
+For more info about AWS authentication, see the [comprehensive docs](http://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html) at AWS.
+
+
+### Install
+
+Go get it:
+
+	$ go get github.com/smartystreets/go-aws-auth
+	
+Then import it:
+
+	import "github.com/smartystreets/go-aws-auth"
+
+
+### Using your AWS Credentials
+
+The library looks for credentials in this order:
+
+1. **Hard-code:** You can manually pass in an instance of `awsauth.Credentials` to any call to a signing function as a second argument:
+
+	```go
+	awsauth.Sign(req, awsauth.Credentials{
+		AccessKeyID: "Access Key ID", 
+		SecretAccessKey: "Secret Access Key",
+		SecurityToken: "Security Token",	// STS (optional)
+	})
+	```
+
+
+2. **Environment variables:** Set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables with your credentials. The library will automatically detect and use them. Optionally, you may also set the `AWS_SECURITY_TOKEN` environment variable if you are using temporary credentials from [STS](http://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html).
+
+3. **IAM Role:** If running on EC2 and the credentials are neither hard-coded nor in the environment, go-aws-auth will detect the first IAM role assigned to the current EC2 instance and use those credentials.
+
+(Be especially careful hard-coding credentials into your application if the code is committed to source control.)
+
+
+
+### Signing requests
+
+Just make the request, have it signed, and perform the request as you normally would.
+
+```go
+url := "https://iam.amazonaws.com/?Action=ListRoles&Version=2010-05-08"
+client := new(http.Client)
+
+req, err := http.NewRequest("GET", url, nil)
+
+awsauth.Sign(req)  // Automatically chooses the best signing mechanism for the service
+
+resp, err := client.Do(req)
+```
+
+You can use `Sign` to have the library choose the best signing algorithm depending on the service, or you can specify it manually if you know what you need:
+
+- `Sign2`
+- `Sign3`
+- `Sign4`
+- `SignS3` (deprecated for Sign4)
+- `SignS3Url` (for pre-signed S3 URLs; GETs only)
+
+
+
+### Contributing
+
+Please feel free to contribute! Bug fixes are more than welcome any time, as long as tests assert correct behavior. If you'd like to change an existing implementation or see a new feature, open an issue first so we can discuss it. Thanks to all contributors!

--- a/vendor/github.com/smartystreets/go-aws-auth/awsauth.go
+++ b/vendor/github.com/smartystreets/go-aws-auth/awsauth.go
@@ -1,0 +1,220 @@
+// Package awsauth implements AWS request signing using Signed Signature Version 2,
+// Signed Signature Version 3, and Signed Signature Version 4. Supports S3 and STS.
+package awsauth
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Credentials stores the information necessary to authorize with AWS and it
+// is from this information that requests are signed.
+type Credentials struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	SecurityToken   string `json:"Token"`
+	Expiration      time.Time
+}
+
+// Sign signs a request bound for AWS. It automatically chooses the best
+// authentication scheme based on the service the request is going to.
+func Sign(request *http.Request, credentials ...Credentials) *http.Request {
+	service, _ := serviceAndRegion(request.URL.Host)
+	signVersion := awsSignVersion[service]
+
+	switch signVersion {
+	case 2:
+		return Sign2(request, credentials...)
+	case 3:
+		return Sign3(request, credentials...)
+	case 4:
+		return Sign4(request, credentials...)
+	case -1:
+		return SignS3(request, credentials...)
+	}
+
+	return nil
+}
+
+// Sign4 signs a request with Signed Signature Version 4.
+func Sign4(request *http.Request, credentials ...Credentials) *http.Request {
+	keys := chooseKeys(credentials)
+
+	// Add the X-Amz-Security-Token header when using STS
+	if keys.SecurityToken != "" {
+		request.Header.Set("X-Amz-Security-Token", keys.SecurityToken)
+	}
+
+	prepareRequestV4(request)
+	meta := new(metadata)
+
+	// Task 1
+	hashedCanonReq := hashedCanonicalRequestV4(request, meta)
+
+	// Task 2
+	stringToSign := stringToSignV4(request, hashedCanonReq, meta)
+
+	// Task 3
+	signingKey := signingKeyV4(keys.SecretAccessKey, meta.date, meta.region, meta.service)
+	signature := signatureV4(signingKey, stringToSign)
+
+	request.Header.Set("Authorization", buildAuthHeaderV4(signature, meta, keys))
+
+	return request
+}
+
+// Sign3 signs a request with Signed Signature Version 3.
+// If the service you're accessing supports Version 4, use that instead.
+func Sign3(request *http.Request, credentials ...Credentials) *http.Request {
+	keys := chooseKeys(credentials)
+
+	// Add the X-Amz-Security-Token header when using STS
+	if keys.SecurityToken != "" {
+		request.Header.Set("X-Amz-Security-Token", keys.SecurityToken)
+	}
+
+	prepareRequestV3(request)
+
+	// Task 1
+	stringToSign := stringToSignV3(request)
+
+	// Task 2
+	signature := signatureV3(stringToSign, keys)
+
+	// Task 3
+	request.Header.Set("X-Amzn-Authorization", buildAuthHeaderV3(signature, keys))
+
+	return request
+}
+
+// Sign2 signs a request with Signed Signature Version 2.
+// If the service you're accessing supports Version 4, use that instead.
+func Sign2(request *http.Request, credentials ...Credentials) *http.Request {
+	keys := chooseKeys(credentials)
+
+	// Add the SecurityToken parameter when using STS
+	// This must be added before the signature is calculated
+	if keys.SecurityToken != "" {
+		values := url.Values{}
+		values.Set("SecurityToken", keys.SecurityToken)
+		augmentRequestQuery(request, values)
+	}
+
+	prepareRequestV2(request, keys)
+
+	stringToSign := stringToSignV2(request)
+	signature := signatureV2(stringToSign, keys)
+
+	values := url.Values{}
+	values.Set("Signature", signature)
+
+	augmentRequestQuery(request, values)
+
+	return request
+}
+
+// SignS3 signs a request bound for Amazon S3 using their custom
+// HTTP authentication scheme.
+func SignS3(request *http.Request, credentials ...Credentials) *http.Request {
+	keys := chooseKeys(credentials)
+
+	// Add the X-Amz-Security-Token header when using STS
+	if keys.SecurityToken != "" {
+		request.Header.Set("X-Amz-Security-Token", keys.SecurityToken)
+	}
+
+	prepareRequestS3(request)
+
+	stringToSign := stringToSignS3(request)
+	signature := signatureS3(stringToSign, keys)
+
+	authHeader := "AWS " + keys.AccessKeyID + ":" + signature
+	request.Header.Set("Authorization", authHeader)
+
+	return request
+}
+
+// SignS3Url signs a GET request for a resource on Amazon S3 by appending
+// query string parameters containing credentials and signature. You must
+// specify an expiration date for these signed requests. After that date,
+// a request signed with this method will be rejected by S3.
+func SignS3Url(request *http.Request, expire time.Time, credentials ...Credentials) *http.Request {
+	keys := chooseKeys(credentials)
+
+	stringToSign := stringToSignS3Url("GET", expire, request.URL.Path)
+	signature := signatureS3(stringToSign, keys)
+
+	query := request.URL.Query()
+	query.Set("AWSAccessKeyId", keys.AccessKeyID)
+	query.Set("Signature", signature)
+	query.Set("Expires", timeToUnixEpochString(expire))
+	request.URL.RawQuery = query.Encode()
+
+	return request
+}
+
+// expired checks to see if the temporary credentials from an IAM role are
+// within 4 minutes of expiration (The IAM documentation says that new keys
+// will be provisioned 5 minutes before the old keys expire). Credentials
+// that do not have an Expiration cannot expire.
+func (this *Credentials) expired() bool {
+	if this.Expiration.IsZero() {
+		// Credentials with no expiration can't expire
+		return false
+	}
+	expireTime := this.Expiration.Add(-4 * time.Minute)
+	// if t - 4 mins is before now, true
+	if expireTime.Before(time.Now()) {
+		return true
+	} else {
+		return false
+	}
+}
+
+type metadata struct {
+	algorithm       string
+	credentialScope string
+	signedHeaders   string
+	date            string
+	region          string
+	service         string
+}
+
+const (
+	envAccessKey       = "AWS_ACCESS_KEY"
+	envAccessKeyID     = "AWS_ACCESS_KEY_ID"
+	envSecretKey       = "AWS_SECRET_KEY"
+	envSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
+	envSecurityToken   = "AWS_SECURITY_TOKEN"
+)
+
+var (
+	awsSignVersion = map[string]int{
+		"autoscaling":          4,
+		"cloudfront":           4,
+		"cloudformation":       4,
+		"cloudsearch":          4,
+		"monitoring":           4,
+		"dynamodb":             4,
+		"ec2":                  2,
+		"elasticmapreduce":     4,
+		"elastictranscoder":    4,
+		"elasticache":          2,
+		"es":                   4,
+		"glacier":              4,
+		"kinesis":              4,
+		"redshift":             4,
+		"rds":                  4,
+		"sdb":                  2,
+		"sns":                  4,
+		"sqs":                  4,
+		"s3":                   4,
+		"elasticbeanstalk":     4,
+		"importexport":         2,
+		"iam":                  4,
+		"route53":              3,
+		"elasticloadbalancing": 4,
+		"email":                3,
+	}
+)

--- a/vendor/github.com/smartystreets/go-aws-auth/common.go
+++ b/vendor/github.com/smartystreets/go-aws-auth/common.go
@@ -1,0 +1,311 @@
+package awsauth
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+type location struct {
+	ec2     bool
+	checked bool
+}
+
+var loc *location
+
+// serviceAndRegion parsers a hostname to find out which ones it is.
+// http://docs.aws.amazon.com/general/latest/gr/rande.html
+func serviceAndRegion(host string) (service string, region string) {
+	// These are the defaults if the hostname doesn't suggest something else
+	region = "us-east-1"
+	service = "s3"
+
+	parts := strings.Split(host, ".")
+	if len(parts) == 4 {
+		// Either service.region.amazonaws.com or virtual-host.region.amazonaws.com
+		if parts[1] == "s3" {
+			service = "s3"
+		} else if strings.HasPrefix(parts[1], "s3-") {
+			region = parts[1][3:]
+			service = "s3"
+		} else {
+			service = parts[0]
+			region = parts[1]
+		}
+	} else if len(parts) == 5 {
+		service = parts[2]
+		region = parts[1]
+	} else {
+		// Either service.amazonaws.com or s3-region.amazonaws.com
+		if strings.HasPrefix(parts[0], "s3-") {
+			region = parts[0][3:]
+		} else {
+			service = parts[0]
+		}
+	}
+
+	if region == "external-1" {
+		region = "us-east-1"
+	}
+
+	return
+}
+
+// newKeys produces a set of credentials based on the environment
+func newKeys() (newCredentials Credentials) {
+	// First use credentials from environment variables
+	newCredentials.AccessKeyID = os.Getenv(envAccessKeyID)
+	if newCredentials.AccessKeyID == "" {
+		newCredentials.AccessKeyID = os.Getenv(envAccessKey)
+	}
+
+	newCredentials.SecretAccessKey = os.Getenv(envSecretAccessKey)
+	if newCredentials.SecretAccessKey == "" {
+		newCredentials.SecretAccessKey = os.Getenv(envSecretKey)
+	}
+
+	newCredentials.SecurityToken = os.Getenv(envSecurityToken)
+
+	// If there is no Access Key and you are on EC2, get the key from the role
+	if (newCredentials.AccessKeyID == "" || newCredentials.SecretAccessKey == "") && onEC2() {
+		newCredentials = *getIAMRoleCredentials()
+	}
+
+	// If the key is expiring, get a new key
+	if newCredentials.expired() && onEC2() {
+		newCredentials = *getIAMRoleCredentials()
+	}
+
+	return newCredentials
+}
+
+// checkKeys gets credentials depending on if any were passed in as an argument
+// or it makes new ones based on the environment.
+func chooseKeys(cred []Credentials) Credentials {
+	if len(cred) == 0 {
+		return newKeys()
+	} else {
+		return cred[0]
+	}
+}
+
+// onEC2 checks to see if the program is running on an EC2 instance.
+// It does this by looking for the EC2 metadata service.
+// This caches that information in a struct so that it doesn't waste time.
+func onEC2() bool {
+	if loc == nil {
+		loc = &location{}
+	}
+	if !(loc.checked) {
+		c, err := net.DialTimeout("tcp", "169.254.169.254:80", time.Millisecond*100)
+
+		if err != nil {
+			loc.ec2 = false
+		} else {
+			c.Close()
+			loc.ec2 = true
+		}
+		loc.checked = true
+	}
+
+	return loc.ec2
+}
+
+// getIAMRoleList gets a list of the roles that are available to this instance
+func getIAMRoleList() []string {
+
+	var roles []string
+	url := "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+
+	client := &http.Client{}
+
+	request, err := http.NewRequest("GET", url, nil)
+
+	if err != nil {
+		return roles
+	}
+
+	response, err := client.Do(request)
+
+	if err != nil {
+		return roles
+	}
+	defer response.Body.Close()
+
+	scanner := bufio.NewScanner(response.Body)
+	for scanner.Scan() {
+		roles = append(roles, scanner.Text())
+	}
+	return roles
+}
+
+func getIAMRoleCredentials() *Credentials {
+
+	roles := getIAMRoleList()
+
+	if len(roles) < 1 {
+		return &Credentials{}
+	}
+
+	// Use the first role in the list
+	role := roles[0]
+
+	url := "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+
+	// Create the full URL of the role
+	var buffer bytes.Buffer
+	buffer.WriteString(url)
+	buffer.WriteString(role)
+	roleURL := buffer.String()
+
+	// Get the role
+	roleRequest, err := http.NewRequest("GET", roleURL, nil)
+
+	if err != nil {
+		return &Credentials{}
+	}
+
+	client := &http.Client{}
+	roleResponse, err := client.Do(roleRequest)
+
+	if err != nil {
+		return &Credentials{}
+	}
+	defer roleResponse.Body.Close()
+
+	roleBuffer := new(bytes.Buffer)
+	roleBuffer.ReadFrom(roleResponse.Body)
+
+	credentials := Credentials{}
+
+	err = json.Unmarshal(roleBuffer.Bytes(), &credentials)
+
+	if err != nil {
+		return &Credentials{}
+	}
+
+	return &credentials
+
+}
+
+func augmentRequestQuery(request *http.Request, values url.Values) *http.Request {
+	for key, array := range request.URL.Query() {
+		for _, value := range array {
+			values.Set(key, value)
+		}
+	}
+
+	request.URL.RawQuery = values.Encode()
+
+	return request
+}
+
+func hmacSHA256(key []byte, content string) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(content))
+	return mac.Sum(nil)
+}
+
+func hmacSHA1(key []byte, content string) []byte {
+	mac := hmac.New(sha1.New, key)
+	mac.Write([]byte(content))
+	return mac.Sum(nil)
+}
+
+func hashSHA256(content []byte) string {
+	h := sha256.New()
+	h.Write(content)
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func hashMD5(content []byte) string {
+	h := md5.New()
+	h.Write(content)
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+func readAndReplaceBody(request *http.Request) []byte {
+	if request.Body == nil {
+		return []byte{}
+	}
+	payload, _ := ioutil.ReadAll(request.Body)
+	request.Body = ioutil.NopCloser(bytes.NewReader(payload))
+	return payload
+}
+
+func concat(delim string, str ...string) string {
+	return strings.Join(str, delim)
+}
+
+var now = func() time.Time {
+	return time.Now().UTC()
+}
+
+func normuri(uri string) string {
+	parts := strings.Split(uri, "/")
+	for i := range parts {
+		parts[i] = encodePathFrag(parts[i])
+	}
+	return strings.Join(parts, "/")
+}
+
+func encodePathFrag(s string) string {
+	hexCount := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if shouldEscape(c) {
+			hexCount++
+		}
+	}
+	t := make([]byte, len(s)+2*hexCount)
+	j := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if shouldEscape(c) {
+			t[j] = '%'
+			t[j+1] = "0123456789ABCDEF"[c>>4]
+			t[j+2] = "0123456789ABCDEF"[c&15]
+			j += 3
+		} else {
+			t[j] = c
+			j++
+		}
+	}
+	return string(t)
+}
+
+func shouldEscape(c byte) bool {
+	if 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' {
+		return false
+	}
+	if '0' <= c && c <= '9' {
+		return false
+	}
+	if c == '-' || c == '_' || c == '.' || c == '~' {
+		return false
+	}
+	return true
+}
+
+func normquery(v url.Values) string {
+	queryString := v.Encode()
+
+	// Go encodes a space as '+' but Amazon requires '%20'. Luckily any '+' in the
+	// original query string has been percent escaped so all '+' chars that are left
+	// were originally spaces.
+
+	return strings.Replace(queryString, "+", "%20", -1)
+}

--- a/vendor/github.com/smartystreets/go-aws-auth/s3.go
+++ b/vendor/github.com/smartystreets/go-aws-auth/s3.go
@@ -1,0 +1,121 @@
+package awsauth
+
+import (
+	"encoding/base64"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func signatureS3(stringToSign string, keys Credentials) string {
+	hashed := hmacSHA1([]byte(keys.SecretAccessKey), stringToSign)
+	return base64.StdEncoding.EncodeToString(hashed)
+}
+
+func stringToSignS3(request *http.Request) string {
+	str := request.Method + "\n"
+
+	if request.Header.Get("Content-Md5") != "" {
+		str += request.Header.Get("Content-Md5")
+	} else {
+		body := readAndReplaceBody(request)
+		if len(body) > 0 {
+			str += hashMD5(body)
+		}
+	}
+	str += "\n"
+
+	str += request.Header.Get("Content-Type") + "\n"
+
+	if request.Header.Get("Date") != "" {
+		str += request.Header.Get("Date")
+	} else {
+		str += timestampS3()
+	}
+
+	str += "\n"
+
+	canonicalHeaders := canonicalAmzHeadersS3(request)
+	if canonicalHeaders != "" {
+		str += canonicalHeaders
+	}
+
+	str += canonicalResourceS3(request)
+
+	return str
+}
+
+func stringToSignS3Url(method string, expire time.Time, path string) string {
+	return method + "\n\n\n" + timeToUnixEpochString(expire) + "\n" + path
+}
+
+func timeToUnixEpochString(t time.Time) string {
+	return strconv.FormatInt(t.Unix(), 10)
+}
+
+func canonicalAmzHeadersS3(request *http.Request) string {
+	var headers []string
+
+	for header := range request.Header {
+		standardized := strings.ToLower(strings.TrimSpace(header))
+		if strings.HasPrefix(standardized, "x-amz") {
+			headers = append(headers, standardized)
+		}
+	}
+
+	sort.Strings(headers)
+
+	for i, header := range headers {
+		headers[i] = header + ":" + strings.Replace(request.Header.Get(header), "\n", " ", -1)
+	}
+
+	if len(headers) > 0 {
+		return strings.Join(headers, "\n") + "\n"
+	} else {
+		return ""
+	}
+}
+
+func canonicalResourceS3(request *http.Request) string {
+	res := ""
+
+	if isS3VirtualHostedStyle(request) {
+		bucketname := strings.Split(request.Host, ".")[0]
+		res += "/" + bucketname
+	}
+
+	res += request.URL.Path
+
+	for _, subres := range strings.Split(subresourcesS3, ",") {
+		if strings.HasPrefix(request.URL.RawQuery, subres) {
+			res += "?" + subres
+		}
+	}
+
+	return res
+}
+
+func prepareRequestS3(request *http.Request) *http.Request {
+	request.Header.Set("Date", timestampS3())
+	if request.URL.Path == "" {
+		request.URL.Path += "/"
+	}
+	return request
+}
+
+// Info: http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html
+func isS3VirtualHostedStyle(request *http.Request) bool {
+	service, _ := serviceAndRegion(request.Host)
+	return service == "s3" && strings.Count(request.Host, ".") == 3
+}
+
+func timestampS3() string {
+	return now().Format(timeFormatS3)
+}
+
+const (
+	timeFormatS3   = time.RFC1123Z
+	subresourcesS3 = "acl,lifecycle,location,logging,notification,partNumber,policy,requestPayment,torrent,uploadId,uploads,versionId,versioning,versions,website"
+)

--- a/vendor/github.com/smartystreets/go-aws-auth/sign2.go
+++ b/vendor/github.com/smartystreets/go-aws-auth/sign2.go
@@ -1,0 +1,50 @@
+package awsauth
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+func prepareRequestV2(request *http.Request, keys Credentials) *http.Request {
+
+	keyID := keys.AccessKeyID
+
+	values := url.Values{}
+	values.Set("AWSAccessKeyId", keyID)
+	values.Set("SignatureVersion", "2")
+	values.Set("SignatureMethod", "HmacSHA256")
+	values.Set("Timestamp", timestampV2())
+
+	augmentRequestQuery(request, values)
+
+	if request.URL.Path == "" {
+		request.URL.Path += "/"
+	}
+
+	return request
+}
+
+func stringToSignV2(request *http.Request) string {
+	str := request.Method + "\n"
+	str += strings.ToLower(request.URL.Host) + "\n"
+	str += request.URL.Path + "\n"
+	str += canonicalQueryStringV2(request)
+	return str
+}
+
+func signatureV2(strToSign string, keys Credentials) string {
+	hashed := hmacSHA256([]byte(keys.SecretAccessKey), strToSign)
+	return base64.StdEncoding.EncodeToString(hashed)
+}
+
+func canonicalQueryStringV2(request *http.Request) string {
+	return request.URL.RawQuery
+}
+
+func timestampV2() string {
+	return now().Format(timeFormatV2)
+}
+
+const timeFormatV2 = "2006-01-02T15:04:05"

--- a/vendor/github.com/smartystreets/go-aws-auth/sign3.go
+++ b/vendor/github.com/smartystreets/go-aws-auth/sign3.go
@@ -1,0 +1,58 @@
+// Thanks to Michael Vierling for contributing sign3.go
+
+package awsauth
+
+import (
+	"encoding/base64"
+	"net/http"
+	"time"
+)
+
+func stringToSignV3(request *http.Request) string {
+	// TASK 1. http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/RESTAuthentication.html#StringToSign
+
+	return request.Header.Get("Date") + request.Header.Get("x-amz-nonce")
+}
+
+func signatureV3(stringToSign string, keys Credentials) string {
+	// TASK 2. http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/RESTAuthentication.html#Signature
+
+	hash := hmacSHA256([]byte(keys.SecretAccessKey), stringToSign)
+	return base64.StdEncoding.EncodeToString(hash)
+}
+
+func buildAuthHeaderV3(signature string, keys Credentials) string {
+	// TASK 3. http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/RESTAuthentication.html#AuthorizationHeader
+
+	return "AWS3-HTTPS AWSAccessKeyId=" + keys.AccessKeyID +
+		", Algorithm=HmacSHA256" +
+		", Signature=" + signature
+}
+
+func prepareRequestV3(request *http.Request) *http.Request {
+	ts := timestampV3()
+	necessaryDefaults := map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+		"x-amz-date":   ts,
+		"Date":         ts,
+		"x-amz-nonce":  "",
+	}
+
+	for header, value := range necessaryDefaults {
+		if request.Header.Get(header) == "" {
+			request.Header.Set(header, value)
+		}
+	}
+
+	if request.URL.Path == "" {
+		request.URL.Path += "/"
+	}
+
+	return request
+}
+
+func timestampV3() string {
+	return now().Format(timeFormatV3)
+}
+
+const timeFormatV3 = time.RFC1123

--- a/vendor/github.com/smartystreets/go-aws-auth/sign4.go
+++ b/vendor/github.com/smartystreets/go-aws-auth/sign4.go
@@ -1,0 +1,117 @@
+package awsauth
+
+import (
+	"encoding/hex"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+func hashedCanonicalRequestV4(request *http.Request, meta *metadata) string {
+	// TASK 1. http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+
+	payload := readAndReplaceBody(request)
+	payloadHash := hashSHA256(payload)
+	request.Header.Set("X-Amz-Content-Sha256", payloadHash)
+
+	// Set this in header values to make it appear in the range of headers to sign
+	request.Header.Set("Host", request.Host)
+
+	var sortedHeaderKeys []string
+	for key, _ := range request.Header {
+		switch key {
+		case "Content-Type", "Content-Md5", "Host":
+		default:
+			if !strings.HasPrefix(key, "X-Amz-") {
+				continue
+			}
+		}
+		sortedHeaderKeys = append(sortedHeaderKeys, strings.ToLower(key))
+	}
+	sort.Strings(sortedHeaderKeys)
+
+	var headersToSign string
+	for _, key := range sortedHeaderKeys {
+		value := strings.TrimSpace(request.Header.Get(key))
+		if key == "host" {
+			//AWS does not include port in signing request.
+			if strings.Contains(value, ":") {
+				split := strings.Split(value, ":")
+				port := split[1]
+				if port == "80" || port == "443" {
+					value = split[0]
+				}
+			}
+		}
+		headersToSign += key + ":" + value + "\n"
+	}
+	meta.signedHeaders = concat(";", sortedHeaderKeys...)
+	canonicalRequest := concat("\n", request.Method, normuri(request.URL.Path), normquery(request.URL.Query()), headersToSign, meta.signedHeaders, payloadHash)
+
+	return hashSHA256([]byte(canonicalRequest))
+}
+
+func stringToSignV4(request *http.Request, hashedCanonReq string, meta *metadata) string {
+	// TASK 2. http://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html
+
+	requestTs := request.Header.Get("X-Amz-Date")
+
+	meta.algorithm = "AWS4-HMAC-SHA256"
+	meta.service, meta.region = serviceAndRegion(request.Host)
+	meta.date = tsDateV4(requestTs)
+	meta.credentialScope = concat("/", meta.date, meta.region, meta.service, "aws4_request")
+
+	return concat("\n", meta.algorithm, requestTs, meta.credentialScope, hashedCanonReq)
+}
+
+func signatureV4(signingKey []byte, stringToSign string) string {
+	// TASK 3. http://docs.aws.amazon.com/general/latest/gr/sigv4-calculate-signature.html
+
+	return hex.EncodeToString(hmacSHA256(signingKey, stringToSign))
+}
+
+func prepareRequestV4(request *http.Request) *http.Request {
+	necessaryDefaults := map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+		"X-Amz-Date":   timestampV4(),
+	}
+
+	for header, value := range necessaryDefaults {
+		if request.Header.Get(header) == "" {
+			request.Header.Set(header, value)
+		}
+	}
+
+	if request.URL.Path == "" {
+		request.URL.Path += "/"
+	}
+
+	return request
+}
+
+func signingKeyV4(secretKey, date, region, service string) []byte {
+	kDate := hmacSHA256([]byte("AWS4"+secretKey), date)
+	kRegion := hmacSHA256(kDate, region)
+	kService := hmacSHA256(kRegion, service)
+	kSigning := hmacSHA256(kService, "aws4_request")
+	return kSigning
+}
+
+func buildAuthHeaderV4(signature string, meta *metadata, keys Credentials) string {
+	credential := keys.AccessKeyID + "/" + meta.credentialScope
+
+	return meta.algorithm +
+		" Credential=" + credential +
+		", SignedHeaders=" + meta.signedHeaders +
+		", Signature=" + signature
+}
+
+func timestampV4() string {
+	return now().Format(timeFormatV4)
+}
+
+func tsDateV4(timestamp string) string {
+	return timestamp[:8]
+}
+
+const timeFormatV4 = "20060102T150405Z"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -238,6 +238,12 @@
 			"revisionTime": "2017-06-07T22:27:57Z"
 		},
 		{
+			"checksumSHA1": "iy7TNc01LWFOGwRwD6v0iDRqtLU=",
+			"path": "github.com/smartystreets/go-aws-auth",
+			"revision": "8ef1316913ee4f44bc48c2456e44a5c1c68ea53b",
+			"revisionTime": "2017-05-04T20:50:21Z"
+		},
+		{
 			"checksumSHA1": "f4m09DHEetaanti/GqUJzyCBTaI=",
 			"path": "github.com/smartystreets/goconvey/convey",
 			"revision": "e5b2b7c9111590d019a696c7800593f666e1a7f4",


### PR DESCRIPTION
### What

The AWS managed Elasticsearch for CMD is restricted to the web / publishing IAM roles. The web role is restricted to HTTP GET requests against the elasticsearch domain. The publishing IAM role also allows PUT, POST, and DELETE requests. 

For the apps to make requests to elastic search they much sign the request against the IAM role, which is what this change enables.

### How to review

Review code changes

### Who can review

Anyone
