### PR TITLE
Set default ports to match dp-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Scripts for updating and debugging Kafka can be found [here](https://github.com/
 | -------------------------- | -------------------------------------| -----------
 | BIND_ADDR                  | :22900                               | The host and port to bind to
 | CONSUMER_GROUP             | dp-search-builder                    | The name of the Kafka consumer group
-| ELASTIC_SEARCH_URL         | http://localhost:9200                | The host name for elasticsearch
+| ELASTIC_SEARCH_URL         | http://localhost:10200               | The host name for elasticsearch
 | EVENT_REPORTER_TOPIC       | report-events                        | The kafka topic to send errors to
 | GRACEFUL_SHUTDOWN_TIMEOUT  | 5s                                   | The graceful shutdown timeout
 | HEALTHCHECK_INTERVAL       | 60s                                  | The interval between healthchecks

--- a/config/config.go
+++ b/config/config.go
@@ -38,7 +38,7 @@ func Get() (*Config, error) {
 		Brokers:                   []string{"localhost:9092"},
 		ConsumerGroup:             "dp-search-builder",
 		ConsumerTopic:             "hierarchy-built",
-		ElasticSearchAPIURL:       "http://localhost:9200",
+		ElasticSearchAPIURL:       "http://localhost:10200",
 		EventReporterTopic:        "report-events",
 		GracefulShutdownTimeout:   5 * time.Second,
 		HealthcheckInterval:       time.Minute,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.Brokers[0], ShouldEqual, "localhost:9092")
 				So(cfg.ConsumerGroup, ShouldEqual, "dp-search-builder")
 				So(cfg.ConsumerTopic, ShouldEqual, "hierarchy-built")
-				So(cfg.ElasticSearchAPIURL, ShouldEqual, "http://localhost:9200")
+				So(cfg.ElasticSearchAPIURL, ShouldEqual, "http://localhost:10200")
 				So(cfg.EventReporterTopic, ShouldEqual, "report-events")
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
 				So(cfg.HealthcheckInterval, ShouldEqual, 60*time.Second)


### PR DESCRIPTION
### What

Set default ports to match dp-compose

- going through the getting started guide suggests using dp-compose to start two instances of elastic search. This service uses the default elastic search port, which is not the right port when using dp-compose. To remove friction from the setup process I have set the default to align with dp-compose and the getting started guide.

### How to review

Review changes, considering how you have this setup

### Who can review

Anyone
