### PR TITLE
Reduce healthy deadline for nomad deploy of service

### DIFF
--- a/dp-search-builder.nomad
+++ b/dp-search-builder.nomad
@@ -12,7 +12,7 @@ job "dp-search-builder" {
   update {
     stagger          = "60s"
     min_healthy_time = "30s"
-    healthy_deadline = "10m"
+    healthy_deadline = "5m"
     max_parallel     = 1
     auto_revert      = true
   }


### PR DESCRIPTION
### What

See title

This is because the progress deadline is set to 10 minutes (default) and the healthy deadline must be less than this for deployment of the service to go ahead (otherwise fails validation prior to even trying to deploy).

### How to review

Check changes make sense, no typo!

### Who can review

Anyone
