### PR TITLE
Rename from dp-search-builder

### DIFF
--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -2,6 +2,6 @@ FROM onsdigital/dp-concourse-tools-ubuntu
 
 WORKDIR /app/
 
-ADD dp-search-builder .
+ADD dp-dimension-search-builder .
 
-CMD ./dp-search-builder
+CMD ./dp-dimension-search-builder

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL=bash
-MAIN=dp-search-builder
+MAIN=dp-dimension-search-builder
 
 BUILD=build
 BIN_DIR?=.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-dp-search-builder
-==================
+dp-dimension-search-builder
+===========================
 
 Handles inserting of dimension options into elasticsearch once a hierarchy for an instance becomes available;
 and creates an event by sending a message to the kafka `$PRODUCER_TOPIC` so services know when the data has successfully been inserted into elastic.
@@ -23,7 +23,7 @@ Refer to https://github.com/ONSdigital/dp-import#dp-import for infrastructure se
 
 ### Getting started
 
-* Clone the repo `go get github.com/ONSdigital/dp-search-builder`
+* Clone the repo `go get github.com/ONSdigital/dp-dimension-search-builder`
 * Run zookeeper and then kafka
 * Run elasticsearch
 * Run the hierarchy API, see documentation [here](https://github.com/ONSdigital/dp-hierarchy-api)

--- a/ci/audit.yml
+++ b/ci/audit.yml
@@ -8,8 +8,8 @@ image_resource:
     tag: latest
 
 inputs:
-  - name: dp-search-builder
-    path: dp-search-builder
+  - name: dp-dimension-search-builder
+    path: dp-dimension-search-builder
 
 run:
-  path: dp-search-builder/ci/scripts/audit.sh
+  path: dp-dimension-search-builder/ci/scripts/audit.sh

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -9,10 +9,10 @@ image_resource:
     tag: 1.15.2
 
 inputs:
-  - name: dp-search-builder
+  - name: dp-dimension-search-builder
 
 outputs:
   - name: build
 
 run:
-  path: dp-search-builder/ci/scripts/build.sh
+  path: dp-dimension-search-builder/ci/scripts/build.sh

--- a/ci/scripts/audit.sh
+++ b/ci/scripts/audit.sh
@@ -2,6 +2,6 @@
 
 export cwd=$(pwd)
 
-pushd $cwd/dp-search-builder
+pushd $cwd/dp-dimension-search-builder
   make audit
 popd

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -2,7 +2,7 @@
 
 cwd=$(pwd)
 
-pushd $cwd/dp-search-builder
-  make build && cp build/dp-search-builder $cwd/build
+pushd $cwd/dp-dimension-search-builder
+  make build && cp build/dp-dimension-search-builder $cwd/build
   cp Dockerfile.concourse $cwd/build
 popd

--- a/ci/scripts/unit.sh
+++ b/ci/scripts/unit.sh
@@ -2,6 +2,6 @@
 
 cwd=$(pwd)
 
-pushd $cwd/dp-search-builder
+pushd $cwd/dp-dimension-search-builder
   make test
 popd

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -9,7 +9,7 @@ image_resource:
     tag: 1.15.2
 
 inputs:
-  - name: dp-search-builder
+  - name: dp-dimension-search-builder
 
 run:
-  path: dp-search-builder/ci/scripts/unit.sh
+  path: dp-dimension-search-builder/ci/scripts/unit.sh

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ONSdigital/dp-search-builder/config"
+	"github.com/ONSdigital/dp-dimension-search-builder/config"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/dp-dimension-search-builder.nomad
+++ b/dp-dimension-search-builder.nomad
@@ -1,4 +1,4 @@
-job "dp-search-builder" {
+job "dp-dimension-search-builder" {
   datacenters = ["eu-west-1"]
   region      = "eu"
   type        = "service"
@@ -27,17 +27,17 @@ job "dp-search-builder" {
       mode     = "delay"
     }
 
-    task "dp-search-builder" {
+    task "dp-dimension-search-builder" {
       driver = "docker"
 
       artifact {
-        source = "s3::https://s3-eu-west-1.amazonaws.com/{{DEPLOYMENT_BUCKET}}/dp-search-builder/{{REVISION}}.tar.gz"
+        source = "s3::https://s3-eu-west-1.amazonaws.com/{{DEPLOYMENT_BUCKET}}/dp-dimension-search-builder/{{REVISION}}.tar.gz"
       }
 
       config {
         command = "${NOMAD_TASK_DIR}/start-task"
 
-        args = ["./dp-search-builder"]
+        args = ["./dp-dimension-search-builder"]
 
         image = "{{ECR_URL}}:concourse-{{REVISION}}"
 
@@ -47,7 +47,7 @@ job "dp-search-builder" {
       }
 
       service {
-        name = "dp-search-builder"
+        name = "dp-dimension-search-builder"
 
         port = "http"
         tags = ["publishing"]
@@ -74,7 +74,7 @@ job "dp-search-builder" {
       }
 
       vault {
-        policies = ["dp-search-builder"]
+        policies = ["dp-dimension-search-builder"]
       }
     }
   }

--- a/elasticsearch/api.go
+++ b/elasticsearch/api.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ONSdigital/dp-elasticsearch/v2/elasticsearch"
 	rchttp "github.com/ONSdigital/dp-rchttp"
-	"github.com/ONSdigital/dp-search-builder/models"
+	"github.com/ONSdigital/dp-dimension-search-builder/models"
 	"github.com/ONSdigital/log.go/log"
 )
 

--- a/elasticsearch/elasticsearch.go
+++ b/elasticsearch/elasticsearch.go
@@ -3,7 +3,7 @@ package elasticsearch
 import (
 	"context"
 
-	"github.com/ONSdigital/dp-search-builder/models"
+	"github.com/ONSdigital/dp-dimension-search-builder/models"
 )
 
 // APIer - An interface used to access the ElasticAPI

--- a/event/handler.go
+++ b/event/handler.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/ONSdigital/dp-import/events"
 	kafka "github.com/ONSdigital/dp-kafka/v2"
-	"github.com/ONSdigital/dp-search-builder/elasticsearch"
-	"github.com/ONSdigital/dp-search-builder/hierarchy"
-	"github.com/ONSdigital/dp-search-builder/models"
+	"github.com/ONSdigital/dp-dimension-search-builder/elasticsearch"
+	"github.com/ONSdigital/dp-dimension-search-builder/hierarchy"
+	"github.com/ONSdigital/dp-dimension-search-builder/models"
 	"github.com/ONSdigital/log.go/log"
 )
 

--- a/event/helper.go
+++ b/event/helper.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	hierarchyModel "github.com/ONSdigital/dp-hierarchy-api/models"
-	"github.com/ONSdigital/dp-search-builder/elasticsearch"
-	"github.com/ONSdigital/dp-search-builder/hierarchy"
-	"github.com/ONSdigital/dp-search-builder/models"
+	"github.com/ONSdigital/dp-dimension-search-builder/elasticsearch"
+	"github.com/ONSdigital/dp-dimension-search-builder/hierarchy"
+	"github.com/ONSdigital/dp-dimension-search-builder/models"
 	"github.com/ONSdigital/log.go/log"
 )
 

--- a/event/helper_test.go
+++ b/event/helper_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ONSdigital/dp-hierarchy-api/models"
 
-	"github.com/ONSdigital/dp-search-builder/mocks"
+	"github.com/ONSdigital/dp-dimension-search-builder/mocks"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ONSdigital/dp-search-builder
+module github.com/ONSdigital/dp-dimension-search-builder
 
 go 1.15
 

--- a/initalise/initalise.go
+++ b/initalise/initalise.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	kafka "github.com/ONSdigital/dp-kafka/v2"
 	"github.com/ONSdigital/dp-reporter-client/reporter"
-	"github.com/ONSdigital/dp-search-builder/config"
+	"github.com/ONSdigital/dp-dimension-search-builder/config"
 )
 
 // ExternalServiceList represents a list of services

--- a/main.go
+++ b/main.go
@@ -14,9 +14,9 @@ import (
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	kafka "github.com/ONSdigital/dp-kafka/v2"
 	rchttp "github.com/ONSdigital/dp-rchttp"
-	"github.com/ONSdigital/dp-search-builder/config"
-	"github.com/ONSdigital/dp-search-builder/event"
-	initialise "github.com/ONSdigital/dp-search-builder/initalise"
+	"github.com/ONSdigital/dp-dimension-search-builder/config"
+	"github.com/ONSdigital/dp-dimension-search-builder/event"
+	initialise "github.com/ONSdigital/dp-dimension-search-builder/initalise"
 	"github.com/ONSdigital/go-ns/server"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/gorilla/mux"
@@ -179,17 +179,17 @@ func run(ctx context.Context) error {
 			hasShutdownError = handleShutdownError(shutdownContext, "search built kafka producer", err, hasShutdownError, log.Data{"topic": cfg.ProducerTopic})
 		}
 
-		// If search builder error kafka producer exists, close it
+		// If dimension search builder error kafka producer exists, close it
 		if serviceList.SearchBuilderErrProducer {
-			log.Event(shutdownContext, "closing search builder error kafka producer", log.INFO, log.Data{"topic": cfg.EventReporterTopic})
+			log.Event(shutdownContext, "closing dimension search builder error kafka producer", log.INFO, log.Data{"topic": cfg.EventReporterTopic})
 			err = searchBuilderErrProducer.Close(shutdownContext)
-			hasShutdownError = handleShutdownError(shutdownContext, "search builder error kafka producer", err, hasShutdownError, log.Data{"topic": cfg.EventReporterTopic})
+			hasShutdownError = handleShutdownError(shutdownContext, "dimension search builder error kafka producer", err, hasShutdownError, log.Data{"topic": cfg.EventReporterTopic})
 		}
 
 		// Close consumer loop
-		log.Event(shutdownContext, "closing search builder consumer loop", log.INFO)
+		log.Event(shutdownContext, "closing dimension search builder consumer loop", log.INFO)
 		err = consumer.Close(shutdownContext)
-		hasShutdownError = handleShutdownError(shutdownContext, "search builder consumer loop", err, hasShutdownError, nil)
+		hasShutdownError = handleShutdownError(shutdownContext, "dimension search builder consumer loop", err, hasShutdownError, nil)
 
 		// If kafka consumer exists, close it
 		if serviceList.Consumer {

--- a/mocks/elastisearchapi.go
+++ b/mocks/elastisearchapi.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/ONSdigital/dp-search-builder/models"
+	"github.com/ONSdigital/dp-dimension-search-builder/models"
 )
 
 // ElasticAPI represents a list of error flags to set error in mocked elastic API


### PR DESCRIPTION
### What

Renaming `dp-search-builder` to `dp-dimension-search-builder`.
This PR changes all occurances of `dp-search-builder` except for the default kafka consumer group which will be changed at a later time when the rest of the service has been renamed.

### How to review

Check that all places where the old name is used in the app have been updated with the new name.
Ensure tests, audit and build pass.

### Who can review

Anyone but me