### PR TITLE
Rename dimension-search-built kafka topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Scripts for updating and debugging Kafka can be found [here](https://github.com/
 | HIERARCHY_BUILT_TOPIC        | hierarchy-built                      | The name of the topic to consume messages from
 | KAFKA_ADDR                   | localhost:9092                       | A list of Kafka host addresses
 | KAFKA_MAX_BYTES              | 2000000                              | The max message size for kafka producer
-| PRODUCER_TOPIC               | search-built                         | The name of the topic to produces messages to
+| PRODUCER_TOPIC               | dimension-search-built               | The name of the topic to produces messages to
 | REQUEST_MAX_RETRIES          | 3                                    | The maximum number of request retries messages from
 | SEARCH_BUILDER_URL           | http://localhost:22900               | The host name for the service
 | SIGN_ELASTICSEARCH_REQUESTS  | false                                | Boolean flag to identify whether elasticsearch requests via elastic API need to be signed if elasticsearch cluster is running in aws

--- a/config/config.go
+++ b/config/config.go
@@ -48,7 +48,7 @@ func Get() (*Config, error) {
 		HierarchyAPIURL:            "http://localhost:22600",
 		KafkaMaxBytes:              "2000000",
 		MaxRetries:                 3,
-		ProducerTopic:              "search-built",
+		ProducerTopic:              "dimension-search-built",
 		SearchBuilderURL:           "http://localhost:22900",
 		SignElasticsearchRequests:  false,
 		KafkaVersion:               "1.0.2",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,7 +30,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
 				So(cfg.HierarchyAPIURL, ShouldEqual, "http://localhost:22600")
 				So(cfg.KafkaMaxBytes, ShouldEqual, "2000000")
-				So(cfg.ProducerTopic, ShouldEqual, "search-built")
+				So(cfg.ProducerTopic, ShouldEqual, "dimension-search-built")
 				So(cfg.MaxRetries, ShouldEqual, 3)
 				So(cfg.SearchBuilderURL, ShouldEqual, "http://localhost:22900")
 			})


### PR DESCRIPTION
### What

Renamed the kafka topic produced by the dp-dimension-search-builder and consumed by the dp-import-tracker to dimension-search-built.

This needs to be applied after the secrets in https://github.com/ONSdigital/dp-configs/pull/308 and before the import tracker.

### How to review

Ensure expected topic changed and spelled correctly etc.
Check tests pass

### Who can review

Anyone but me